### PR TITLE
공무원 정보 수정

### DIFF
--- a/src/main/java/kdt/minone/domain/user/controller/AdminController.java
+++ b/src/main/java/kdt/minone/domain/user/controller/AdminController.java
@@ -1,13 +1,14 @@
 package kdt.minone.domain.user.controller;
 
+import jakarta.validation.Valid;
+import kdt.minone.domain.user.dto.EmployeeUpdateByAdminReqDto;
+import kdt.minone.domain.user.dto.EmployeeUpdateByAdminResDto;
 import kdt.minone.domain.user.service.AdminService;
+import kdt.minone.global.common.dto.BaseResDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,5 +25,23 @@ public class AdminController {
         adminService.deleteEmployeeById(employeeId);
 
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @PatchMapping("/{employeeId}")
+    public ResponseEntity<BaseResDto<EmployeeUpdateByAdminResDto>> updateEmployeeById(
+            @PathVariable Long employeeId,
+            @Valid @RequestBody EmployeeUpdateByAdminReqDto dto
+    ) {
+
+        EmployeeUpdateByAdminResDto result = adminService.updateEmployeeById(
+                employeeId,
+                dto.getDepartmentId(),
+                dto.getRole()
+        );
+
+        return new ResponseEntity<>(new BaseResDto<>(
+                "employee update success",
+                result
+        ), HttpStatus.OK);
     }
 }

--- a/src/main/java/kdt/minone/domain/user/controller/AdminController.java
+++ b/src/main/java/kdt/minone/domain/user/controller/AdminController.java
@@ -17,11 +17,11 @@ public class AdminController {
     private final AdminService adminService;
 
     @DeleteMapping("/{employeeId}")
-    public ResponseEntity<Void> deleteEmployee(
+    public ResponseEntity<Void> deleteEmployeeById(
             @PathVariable Long employeeId
     ) {
 
-        adminService.deleteEmployee(employeeId);
+        adminService.deleteEmployeeById(employeeId);
 
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }

--- a/src/main/java/kdt/minone/domain/user/controller/AdminController.java
+++ b/src/main/java/kdt/minone/domain/user/controller/AdminController.java
@@ -1,6 +1,5 @@
 package kdt.minone.domain.user.controller;
 
-import jakarta.validation.Valid;
 import kdt.minone.domain.user.dto.EmployeeUpdateByAdminReqDto;
 import kdt.minone.domain.user.dto.EmployeeUpdateByAdminResDto;
 import kdt.minone.domain.user.service.AdminService;
@@ -30,7 +29,7 @@ public class AdminController {
     @PatchMapping("/{employeeId}")
     public ResponseEntity<BaseResDto<EmployeeUpdateByAdminResDto>> updateEmployeeById(
             @PathVariable Long employeeId,
-            @Valid @RequestBody EmployeeUpdateByAdminReqDto dto
+            @RequestBody EmployeeUpdateByAdminReqDto dto
     ) {
 
         EmployeeUpdateByAdminResDto result = adminService.updateEmployeeById(

--- a/src/main/java/kdt/minone/domain/user/dto/EmployeeUpdateByAdminReqDto.java
+++ b/src/main/java/kdt/minone/domain/user/dto/EmployeeUpdateByAdminReqDto.java
@@ -1,0 +1,13 @@
+package kdt.minone.domain.user.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class EmployeeUpdateByAdminReqDto {
+
+    private final Long departmentId;
+
+    private final String role;
+}

--- a/src/main/java/kdt/minone/domain/user/dto/EmployeeUpdateByAdminResDto.java
+++ b/src/main/java/kdt/minone/domain/user/dto/EmployeeUpdateByAdminResDto.java
@@ -1,0 +1,36 @@
+package kdt.minone.domain.user.dto;
+
+import kdt.minone.domain.department.entity.Department;
+import kdt.minone.domain.user.entity.Employee;
+import kdt.minone.global.common.dto.BaseDtoDataType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class EmployeeUpdateByAdminResDto implements BaseDtoDataType {
+
+    private final Long id;
+    private final Long departmentId;
+    private final String departmentName;
+    private final String email;
+    private final String name;
+    private final String phone;
+    private final String role;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public EmployeeUpdateByAdminResDto(Employee employee, Department department) {
+        this.id = employee.getId();
+        this.departmentId = department.getId();
+        this.departmentName = department.getName();
+        this.email = employee.getEmail();
+        this.name = employee.getName();
+        this.phone = employee.getPhone();
+        this.role = employee.getRole().name();
+        this.createdAt = employee.getCreatedAt();
+        this.updatedAt = employee.getUpdatedAt();
+    }
+}

--- a/src/main/java/kdt/minone/domain/user/entity/Employee.java
+++ b/src/main/java/kdt/minone/domain/user/entity/Employee.java
@@ -70,6 +70,14 @@ public class Employee extends BaseEntity {
         this.phone = phone;
     }
 
+    public void changeDepartment(Department department) {
+        this.department = department;
+    }
+
+    public void changeRole(String role) {
+        this.role = EmployeeRole.valueOf(role.toUpperCase());
+    }
+
     private void assignDefaultRole() {
         if (this.role == null) {
             this.role = EmployeeRole.EMPLOYEE;

--- a/src/main/java/kdt/minone/domain/user/entity/Employee.java
+++ b/src/main/java/kdt/minone/domain/user/entity/Employee.java
@@ -75,7 +75,7 @@ public class Employee extends BaseEntity {
     }
 
     public void changeRole(String role) {
-        this.role = EmployeeRole.valueOf(role.toUpperCase());
+        this.role = EmployeeRole.of(role.toUpperCase());
     }
 
     private void assignDefaultRole() {

--- a/src/main/java/kdt/minone/domain/user/service/AdminService.java
+++ b/src/main/java/kdt/minone/domain/user/service/AdminService.java
@@ -13,7 +13,7 @@ public class AdminService {
     private final EmployeeRepository employeeRepository;
 
     @Transactional
-    public void deleteEmployee(Long employeeId) {
+    public void deleteEmployeeById(Long employeeId) {
         Employee employee = employeeRepository.findByIdOrElseThrow(employeeId);
         employeeRepository.delete(employee);
     }

--- a/src/main/java/kdt/minone/domain/user/service/AdminService.java
+++ b/src/main/java/kdt/minone/domain/user/service/AdminService.java
@@ -1,5 +1,8 @@
 package kdt.minone.domain.user.service;
 
+import kdt.minone.domain.department.entity.Department;
+import kdt.minone.domain.department.repository.DepartmentRepository;
+import kdt.minone.domain.user.dto.EmployeeUpdateByAdminResDto;
 import kdt.minone.domain.user.entity.Employee;
 import kdt.minone.domain.user.repository.EmployeeRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +14,33 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminService {
 
     private final EmployeeRepository employeeRepository;
+    private final DepartmentRepository departmentRepository;
 
     @Transactional
     public void deleteEmployeeById(Long employeeId) {
         Employee employee = employeeRepository.findByIdOrElseThrow(employeeId);
         employeeRepository.delete(employee);
+    }
+
+    @Transactional
+    public EmployeeUpdateByAdminResDto updateEmployeeById(Long employeeId, Long departmentId, String role) {
+        Employee employee = employeeRepository.findByIdOrElseThrow(employeeId);
+        changeRoleIfPresent(role, employee);
+        changeDepartmentIfPresent(departmentId, employee);
+
+        return new EmployeeUpdateByAdminResDto(employee, employee.getDepartment());
+    }
+
+    private void changeDepartmentIfPresent(Long departmentId, Employee employee) {
+        if (departmentId != null) {
+            Department department = departmentRepository.findByIdOrElseThrow(departmentId);
+            employee.changeDepartment(department);
+        }
+    }
+
+    private void changeRoleIfPresent(String role, Employee employee) {
+        if (role != null) {
+            employee.changeRole(role);
+        }
     }
 }

--- a/src/main/java/kdt/minone/global/enums/EmployeeRole.java
+++ b/src/main/java/kdt/minone/global/enums/EmployeeRole.java
@@ -1,10 +1,23 @@
 package kdt.minone.global.enums;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
 public enum EmployeeRole {
 
     EMPLOYEE("민원 처리 담당자"),
     MANAGER("부서 담당자"),
     ADMIN("관리자");
+
+    public static EmployeeRole of(String name) {
+        for (EmployeeRole role : values()) {
+            if (role.name().equals(name)) {
+                return role;
+            }
+        }
+
+        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "not found");
+    }
 
     private final String description;
 


### PR DESCRIPTION
- 부서 또는 권한 변경
- 유효하지 않은 권한에 대해 예외처리

#16

## 고려 사항
- 역할에 따른 기능을 명확하게 표현하기 위해 클래스명을 EmployeeUpdateByAdminReqDto/ResDto 지정 → 클래스명이 길어짐
- 다른 네이밍으로 변경 가능
   - ex)  AdminUpdateEmployeeReqDto/ResDto