### PR TITLE
feat: add delete user api

### DIFF
--- a/src/main/java/kdt/minone/domain/user/controller/UserController.java
+++ b/src/main/java/kdt/minone/domain/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package kdt.minone.domain.user.controller;
 
+import jakarta.validation.Valid;
+import kdt.minone.domain.user.dto.CitizenUpdateReqDto;
 import kdt.minone.domain.user.entity.Citizen;
 import kdt.minone.domain.user.entity.Employee;
 import kdt.minone.domain.user.service.AdminService;
@@ -9,9 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,6 +20,27 @@ public class UserController {
 
     private final CitizenService citizenService;
     private final AdminService adminService;
+
+    @PatchMapping("/me")
+    public ResponseEntity<Void> patchUserPassword(
+            @Valid @RequestBody CitizenUpdateReqDto dto,
+            Authentication authentication
+    ) {
+
+        UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
+
+        String role = userDetails.getAuthorities().iterator().next().getAuthority();
+
+        if (role.equals("ROLE_CITIZEN")) {
+            Citizen citizen = userDetails.getCitizen();
+            citizenService.updateCitizenPassword(citizen.getId(), dto.getOldPassword(), dto.getNewPassword());
+        } else {
+            Employee employee = userDetails.getEmployee();
+            adminService.updateEmployeePassword(employee.getId(), dto.getOldPassword(), dto.getNewPassword());
+        }
+
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
 
     @DeleteMapping("/me")
     public ResponseEntity<Void> deleteUser(

--- a/src/main/java/kdt/minone/domain/user/controller/UserController.java
+++ b/src/main/java/kdt/minone/domain/user/controller/UserController.java
@@ -1,0 +1,43 @@
+package kdt.minone.domain.user.controller;
+
+import kdt.minone.domain.user.entity.Citizen;
+import kdt.minone.domain.user.entity.Employee;
+import kdt.minone.domain.user.service.AdminService;
+import kdt.minone.domain.user.service.CitizenService;
+import kdt.minone.global.config.auth.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+    private final CitizenService citizenService;
+    private final AdminService adminService;
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteUser(
+            Authentication authentication
+    ) {
+
+        UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
+
+        String role = userDetails.getAuthorities().iterator().next().getAuthority();
+
+        if (role.equals("ROLE_CITIZEN")) {
+            Citizen citizen = userDetails.getCitizen();
+            citizenService.deleteCitizenById(citizen.getId());
+        } else {
+            Employee employee = userDetails.getEmployee();
+            adminService.deleteEmployeeById(employee.getId());
+        }
+
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/kdt/minone/domain/user/dto/CitizenUpdateReqDto.java
+++ b/src/main/java/kdt/minone/domain/user/dto/CitizenUpdateReqDto.java
@@ -1,0 +1,12 @@
+package kdt.minone.domain.user.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CitizenUpdateReqDto {
+
+    private final String oldPassword;
+    private final String newPassword;
+}

--- a/src/main/java/kdt/minone/domain/user/entity/Citizen.java
+++ b/src/main/java/kdt/minone/domain/user/entity/Citizen.java
@@ -51,4 +51,8 @@ public class Citizen extends BaseEntity {
         this.password = password;
         this.phone = phone;
     }
+
+    public void updatePassword(String encoded) {
+        this.password = encoded;
+    }
 }

--- a/src/main/java/kdt/minone/domain/user/entity/Employee.java
+++ b/src/main/java/kdt/minone/domain/user/entity/Employee.java
@@ -83,4 +83,8 @@ public class Employee extends BaseEntity {
             this.role = EmployeeRole.EMPLOYEE;
         }
     }
+
+    public void updatePassword(String encoded) {
+        this.password = encoded;
+    }
 }

--- a/src/main/java/kdt/minone/domain/user/repository/CitizenRepository.java
+++ b/src/main/java/kdt/minone/domain/user/repository/CitizenRepository.java
@@ -2,9 +2,15 @@ package kdt.minone.domain.user.repository;
 
 import kdt.minone.domain.user.entity.Citizen;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
 
 public interface CitizenRepository extends JpaRepository<Citizen, Long> {
     Optional<Citizen> findByEmail(String email);
+
+    default Citizen findByIdOrElseThrow(Long id) {
+        return findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "user not found"));
+    }
 }

--- a/src/main/java/kdt/minone/domain/user/service/AdminService.java
+++ b/src/main/java/kdt/minone/domain/user/service/AdminService.java
@@ -6,8 +6,11 @@ import kdt.minone.domain.user.dto.EmployeeUpdateByAdminResDto;
 import kdt.minone.domain.user.entity.Employee;
 import kdt.minone.domain.user.repository.EmployeeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +18,7 @@ public class AdminService {
 
     private final EmployeeRepository employeeRepository;
     private final DepartmentRepository departmentRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public void deleteEmployeeById(Long employeeId) {
@@ -42,5 +46,17 @@ public class AdminService {
         if (role != null) {
             employee.changeRole(role);
         }
+    }
+
+    @Transactional
+    public void updateEmployeePassword(Long id, String oldPassword, String newPassword) {
+
+        Employee employee = employeeRepository.findByIdOrElseThrow(id);
+
+        if (!passwordEncoder.matches(oldPassword, employee.getPassword())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "wrong password");
+        }
+
+        employee.updatePassword(passwordEncoder.encode(newPassword));
     }
 }

--- a/src/main/java/kdt/minone/domain/user/service/CitizenService.java
+++ b/src/main/java/kdt/minone/domain/user/service/CitizenService.java
@@ -4,17 +4,32 @@ import jakarta.transaction.Transactional;
 import kdt.minone.domain.user.entity.Citizen;
 import kdt.minone.domain.user.repository.CitizenRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
 public class CitizenService {
 
     private final CitizenRepository citizenRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public void deleteCitizenById(Long id) {
         Citizen citizen = citizenRepository.findByIdOrElseThrow(id);
         citizenRepository.delete(citizen);
+    }
+
+    @Transactional
+    public void updateCitizenPassword(Long id, String oldPassword, String newPassword) {
+        Citizen savedCitizen = citizenRepository.findByIdOrElseThrow(id);
+
+        if (!passwordEncoder.matches(oldPassword, savedCitizen.getPassword())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "wrong password");
+        }
+
+        savedCitizen.updatePassword(passwordEncoder.encode(newPassword));
     }
 }

--- a/src/main/java/kdt/minone/domain/user/service/CitizenService.java
+++ b/src/main/java/kdt/minone/domain/user/service/CitizenService.java
@@ -1,0 +1,20 @@
+package kdt.minone.domain.user.service;
+
+import jakarta.transaction.Transactional;
+import kdt.minone.domain.user.entity.Citizen;
+import kdt.minone.domain.user.repository.CitizenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CitizenService {
+
+    private final CitizenRepository citizenRepository;
+
+    @Transactional
+    public void deleteCitizenById(Long id) {
+        Citizen citizen = citizenRepository.findByIdOrElseThrow(id);
+        citizenRepository.delete(citizen);
+    }
+}

--- a/src/main/java/kdt/minone/global/config/SecurityConfig.java
+++ b/src/main/java/kdt/minone/global/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/master/**").hasRole(EmployeeRole.ADMIN.name())
+                        .requestMatchers("/api/v1/admin/**").hasRole(EmployeeRole.EMPLOYEE.name())
                         .requestMatchers("/**").permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
회원 탈퇴
- Controller 에서 Citizen/Employee 분기 후 호출
- DELETE /api/v1/users/me
- security role check x

비밀번호 변경 로직
- oldPassword, newPassword
- Controller 분기
- Patch /api/v1/users/me