### PR TITLE
부서 전체 조회

### DIFF
--- a/src/main/java/kdt/minone/domain/department/controller/DepartmentController.java
+++ b/src/main/java/kdt/minone/domain/department/controller/DepartmentController.java
@@ -1,7 +1,9 @@
 package kdt.minone.domain.department.controller;
 
 import kdt.minone.domain.department.dto.DepartmentEmployeeListResDto;
+import kdt.minone.domain.department.dto.DepartmentResDto;
 import kdt.minone.domain.department.service.DepartmentService;
+import kdt.minone.global.common.dto.BaseListResDto;
 import kdt.minone.global.common.dto.BaseResDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -11,12 +13,24 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/departments")
 public class DepartmentController {
 
     private final DepartmentService departmentService;
+
+    @GetMapping
+    public ResponseEntity<BaseListResDto<DepartmentResDto>> findAll() {
+        List<DepartmentResDto> results = departmentService.findAll();
+
+        return new ResponseEntity<>(new BaseListResDto<>(
+                "부서 전체 조회 성공",
+                results
+        ), HttpStatus.OK);
+    }
 
     @GetMapping("/{departmentId}/employees")
     public ResponseEntity<BaseResDto<DepartmentEmployeeListResDto>> findEmployeesById(

--- a/src/main/java/kdt/minone/domain/department/dto/DepartmentResDto.java
+++ b/src/main/java/kdt/minone/domain/department/dto/DepartmentResDto.java
@@ -1,0 +1,19 @@
+package kdt.minone.domain.department.dto;
+
+import kdt.minone.domain.department.entity.Department;
+import kdt.minone.global.common.dto.BaseDtoDataType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class DepartmentResDto implements BaseDtoDataType {
+
+    private final Long id;
+    private final String name;
+
+    public DepartmentResDto(Department department) {
+        this.id = department.getId();
+        this.name = department.getName();
+    }
+}

--- a/src/main/java/kdt/minone/domain/department/service/DepartmentService.java
+++ b/src/main/java/kdt/minone/domain/department/service/DepartmentService.java
@@ -1,6 +1,7 @@
 package kdt.minone.domain.department.service;
 
 import kdt.minone.domain.department.dto.DepartmentEmployeeListResDto;
+import kdt.minone.domain.department.dto.DepartmentResDto;
 import kdt.minone.domain.department.entity.Department;
 import kdt.minone.domain.department.repository.DepartmentRepository;
 import kdt.minone.domain.user.entity.Employee;
@@ -17,6 +18,15 @@ public class DepartmentService {
 
     private final DepartmentRepository departmentRepository;
     private final EmployeeRepository employeeRepository;
+
+    @Transactional(readOnly = true)
+    public List<DepartmentResDto> findAll() {
+        List<Department> departments = departmentRepository.findAll();
+
+        return departments.stream()
+                .map(DepartmentResDto::new)
+                .toList();
+    }
 
     @Transactional(readOnly = true)
     public DepartmentEmployeeListResDto findEmployeesById(Long departmentId) {

--- a/src/main/java/kdt/minone/global/config/SecurityConfig.java
+++ b/src/main/java/kdt/minone/global/config/SecurityConfig.java
@@ -32,9 +32,9 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/**").permitAll()
                         .requestMatchers("/api/v1/master/**").hasRole(EmployeeRole.ADMIN.name())
                         .requestMatchers("/api/v1/admin/**").hasRole(EmployeeRole.EMPLOYEE.name())
-                        .requestMatchers("/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))


### PR DESCRIPTION
## 구현 사항
- 부서 전체 조회 기능 구현

#46

## 수정 사항
- Spring Security requestMatchers 순서 수정
  - Spring Security는 requestMatchers에 먼저 선언된 경로가 우선 적용되기 때문에, 개발용으로 임시 전체 경로를 허용해둔 "/**" 설정이 적용되지 않아 순서 재배치
  - 추후 화이트리스트 추가할 때, "/api/v1/admin/departments" 경로도 화이트리스트에 넣어야 함