### PR TITLE
시민 민원 조회

### DIFF
--- a/src/main/java/kdt/minone/domain/complaint/controller/UserComplaintController.java
+++ b/src/main/java/kdt/minone/domain/complaint/controller/UserComplaintController.java
@@ -1,8 +1,10 @@
 package kdt.minone.domain.complaint.controller;
 
+import kdt.minone.domain.complaint.dto.CitizenComplaintDetailResDto;
 import kdt.minone.domain.complaint.dto.CitizenComplaintListResDto;
 import kdt.minone.domain.complaint.service.UserComplaintService;
 import kdt.minone.global.common.dto.BaseListResDto;
+import kdt.minone.global.common.dto.BaseResDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -39,6 +41,20 @@ public class UserComplaintController {
         return new ResponseEntity<>(new BaseListResDto<>(
                 "시민 민원 전체 조회 성공",
                 results
+        ), HttpStatus.OK);
+    }
+
+    @GetMapping("/{complaintId}")
+    public ResponseEntity<BaseResDto<CitizenComplaintDetailResDto>> findComplaintById(
+            @PathVariable Long userId,
+            @PathVariable Long complaintId
+    ) {
+
+        CitizenComplaintDetailResDto result = userComplaintService.findComplaintById(userId, complaintId);
+
+        return new ResponseEntity<>(new BaseResDto<>(
+                "시민 민원 단건 조회 성공",
+                result
         ), HttpStatus.OK);
     }
 }

--- a/src/main/java/kdt/minone/domain/complaint/controller/UserComplaintController.java
+++ b/src/main/java/kdt/minone/domain/complaint/controller/UserComplaintController.java
@@ -1,0 +1,44 @@
+package kdt.minone.domain.complaint.controller;
+
+import kdt.minone.domain.complaint.dto.CitizenComplaintListResDto;
+import kdt.minone.domain.complaint.service.UserComplaintService;
+import kdt.minone.global.common.dto.BaseListResDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users/{userId}/complaints")
+public class UserComplaintController {
+
+    private final UserComplaintService userComplaintService;
+
+    @GetMapping
+    public ResponseEntity<BaseListResDto<CitizenComplaintListResDto>> searchComplaintsByUser(
+            @PathVariable Long userId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String complaintNo,
+            @RequestParam(required = false) String content,
+            @RequestParam(required = false) String status
+    ) {
+
+        List<CitizenComplaintListResDto> results = userComplaintService.searchComplaintsByUser(
+                userId,
+                page,
+                size,
+                complaintNo,
+                content,
+                status
+        );
+
+        return new ResponseEntity<>(new BaseListResDto<>(
+                "시민 민원 전체 조회 성공",
+                results
+        ), HttpStatus.OK);
+    }
+}

--- a/src/main/java/kdt/minone/domain/complaint/dto/CitizenComplaintDetailResDto.java
+++ b/src/main/java/kdt/minone/domain/complaint/dto/CitizenComplaintDetailResDto.java
@@ -1,0 +1,44 @@
+package kdt.minone.domain.complaint.dto;
+
+import kdt.minone.domain.complaint.entity.Complaint;
+import kdt.minone.domain.complaint.entity.ComplaintResult;
+import kdt.minone.global.common.dto.BaseDtoDataType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class CitizenComplaintDetailResDto implements BaseDtoDataType {
+
+    private final Long id;
+    private final String complaintNo;
+    private final Long departmentId;
+    private final String departmentName;
+    private final Long employeeId;
+    private final String employeeName;
+    private final String address;
+    private final String title;
+    private final String content;
+    private final String status;
+    private final String result;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public CitizenComplaintDetailResDto(Complaint complaint, ComplaintResult complaintResult) {
+        this.id = complaint.getId();
+        this.complaintNo = complaint.getComplaintNo();
+        this.departmentId = complaint.getDepartment().getId();
+        this.departmentName = complaint.getDepartment().getName();
+        this.employeeId = complaint.getEmployee().getId();
+        this.employeeName = complaint.getEmployee().getName();
+        this.address = complaint.getAddress();
+        this.title = complaint.getTitle();
+        this.content = complaint.getContent();
+        this.status = complaint.getStatus().name();
+        this.result = complaintResult.getContent();
+        this.createdAt = complaint.getCreatedAt();
+        this.updatedAt = complaint.getUpdatedAt();
+    }
+}

--- a/src/main/java/kdt/minone/domain/complaint/dto/CitizenComplaintListResDto.java
+++ b/src/main/java/kdt/minone/domain/complaint/dto/CitizenComplaintListResDto.java
@@ -1,0 +1,44 @@
+package kdt.minone.domain.complaint.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import kdt.minone.global.common.dto.BaseDtoDataType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CitizenComplaintListResDto implements BaseDtoDataType {
+
+    private final Long id;
+    private final String complaintNo;
+    private final Long departmentId;
+    private final String departmentName;
+    private final Long employeeId;
+    private final String employeeName;
+    private final String address;
+    private final String title;
+    private final String content;
+    private final String status;
+    private final String result;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    @QueryProjection
+    public CitizenComplaintListResDto(Long id, String complaintNo, Long departmentId, String departmentName,
+                                      Long employeeId, String employeeName, String address, String title, String content,
+                                      String status, String result, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.complaintNo = complaintNo;
+        this.departmentId = departmentId;
+        this.departmentName = departmentName;
+        this.employeeId = employeeId;
+        this.employeeName = employeeName;
+        this.address = address;
+        this.title = title;
+        this.content = content;
+        this.status = status;
+        this.result = result;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/kdt/minone/domain/complaint/entity/Complaint.java
+++ b/src/main/java/kdt/minone/domain/complaint/entity/Complaint.java
@@ -81,12 +81,11 @@ public class Complaint extends BaseEntity {
     private List<ComplaintMemo> complaintMemos = new ArrayList<>();
 
     public Complaint(ChatRoom chatRoom, Citizen citizen, Department department, Employee employee,
-                     String complaintNo, String address, String title, String content, ComplaintStatus status, int priorityScore) {
+                     String address, String title, String content, ComplaintStatus status, int priorityScore) {
         this.chatRoom = chatRoom;
         this.citizen = citizen;
         this.department = department;
         this.employee = employee;
-        this.complaintNo = complaintNo;
         this.address = address;
         this.title = title;
         this.content = content;

--- a/src/main/java/kdt/minone/domain/complaint/repository/ComplaintRepository.java
+++ b/src/main/java/kdt/minone/domain/complaint/repository/ComplaintRepository.java
@@ -5,9 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Optional;
+
 public interface ComplaintRepository extends JpaRepository<Complaint, Long>, CustomComplaintRepository {
 
     default Complaint findByIdOrElseThrow(Long complaintId) {
         return findById(complaintId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "not found"));
     }
+
+    Optional<Complaint> findByIdAndCitizenId(Long complaintId, Long userId);
 }

--- a/src/main/java/kdt/minone/domain/complaint/repository/ComplaintRepository.java
+++ b/src/main/java/kdt/minone/domain/complaint/repository/ComplaintRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
-public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
+public interface ComplaintRepository extends JpaRepository<Complaint, Long>, CustomComplaintRepository {
 
     default Complaint findByIdOrElseThrow(Long complaintId) {
         return findById(complaintId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "not found"));

--- a/src/main/java/kdt/minone/domain/complaint/repository/ComplaintResultRepository.java
+++ b/src/main/java/kdt/minone/domain/complaint/repository/ComplaintResultRepository.java
@@ -10,4 +10,6 @@ public interface ComplaintResultRepository extends JpaRepository<ComplaintResult
     boolean existsByComplaintId(Long complaintId);
 
     Optional<ComplaintResult> findByIdAndComplaintId(Long resultId, Long complaintId);
+
+    Optional<ComplaintResult> findByComplaintId(Long complaintId);
 }

--- a/src/main/java/kdt/minone/domain/complaint/repository/CustomComplaintRepository.java
+++ b/src/main/java/kdt/minone/domain/complaint/repository/CustomComplaintRepository.java
@@ -1,0 +1,10 @@
+package kdt.minone.domain.complaint.repository;
+
+import kdt.minone.domain.complaint.dto.CitizenComplaintListResDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomComplaintRepository {
+
+    Page<CitizenComplaintListResDto> searchComplaintsByUser(Pageable pageable, Long userId, String complaintNo, String content, String status);
+}

--- a/src/main/java/kdt/minone/domain/complaint/repository/CustomComplaintRepositoryImpl.java
+++ b/src/main/java/kdt/minone/domain/complaint/repository/CustomComplaintRepositoryImpl.java
@@ -1,0 +1,81 @@
+package kdt.minone.domain.complaint.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kdt.minone.domain.complaint.dto.CitizenComplaintListResDto;
+import kdt.minone.domain.complaint.dto.QCitizenComplaintListResDto;
+import kdt.minone.domain.complaint.entity.QComplaint;
+import kdt.minone.domain.complaint.entity.QComplaintResult;
+import kdt.minone.domain.department.entity.QDepartment;
+import kdt.minone.domain.user.entity.QEmployee;
+import kdt.minone.global.enums.ComplaintStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class CustomComplaintRepositoryImpl implements CustomComplaintRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<CitizenComplaintListResDto> searchComplaintsByUser(Pageable pageable, Long userId, String complaintNo, String content, String status) {
+        QComplaint complaint = QComplaint.complaint;
+        QDepartment department = QDepartment.department;
+        QEmployee employee = QEmployee.employee;
+        QComplaintResult result = QComplaintResult.complaintResult;
+
+        BooleanBuilder conditions = new BooleanBuilder();
+        conditions.and(complaint.citizen.id.eq(userId));
+
+        if (complaintNo != null) {
+            conditions.and(complaint.complaintNo.contains(complaintNo));
+        }
+
+        if (content != null) {
+            conditions.and(complaint.content.contains(content));
+        }
+
+        if (status != null) {
+            ComplaintStatus enumStatus = ComplaintStatus.of(status.toUpperCase());
+            conditions.and(complaint.status.eq(enumStatus));
+        }
+
+        List<CitizenComplaintListResDto> complaints = jpaQueryFactory
+                .select(new QCitizenComplaintListResDto(
+                        complaint.id,
+                        complaint.complaintNo,
+                        department.id,
+                        department.name,
+                        employee.id,
+                        employee.name,
+                        complaint.address,
+                        complaint.title,
+                        complaint.content,
+                        complaint.status.stringValue(),
+                        result.content,
+                        complaint.createdAt,
+                        complaint.updatedAt
+                ))
+                .from(complaint)
+                .innerJoin(department).on(complaint.department.id.eq(department.id)).fetchJoin()
+                .innerJoin(employee).on(complaint.employee.id.eq(employee.id)).fetchJoin()
+                .innerJoin(result).on(complaint.id.eq(result.complaint.id)).fetchJoin()
+                .where(conditions)
+                .orderBy(complaint.createdAt.desc(), complaint.complaintNo.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = Optional.ofNullable(jpaQueryFactory.select(employee.count())
+                .from(employee)
+                .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(complaints, pageable, total);
+    }
+}

--- a/src/main/java/kdt/minone/domain/complaint/service/UserComplaintService.java
+++ b/src/main/java/kdt/minone/domain/complaint/service/UserComplaintService.java
@@ -1,0 +1,28 @@
+package kdt.minone.domain.complaint.service;
+
+import kdt.minone.domain.complaint.dto.CitizenComplaintListResDto;
+import kdt.minone.domain.complaint.repository.ComplaintRepository;
+import kdt.minone.domain.user.repository.CitizenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserComplaintService {
+
+    private final ComplaintRepository complaintRepository;
+    private final CitizenRepository citizenRepository;
+
+    @Transactional(readOnly = true)
+    public List<CitizenComplaintListResDto> searchComplaintsByUser(Long userId, int page, int size, String complaintNo, String content, String status) {
+        citizenRepository.findByIdOrElseThrow(userId);
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        return complaintRepository.searchComplaintsByUser(pageable, userId, complaintNo, content, status).stream().toList();
+    }
+}

--- a/src/main/java/kdt/minone/domain/complaint/service/UserComplaintService.java
+++ b/src/main/java/kdt/minone/domain/complaint/service/UserComplaintService.java
@@ -1,13 +1,19 @@
 package kdt.minone.domain.complaint.service;
 
+import kdt.minone.domain.complaint.dto.CitizenComplaintDetailResDto;
 import kdt.minone.domain.complaint.dto.CitizenComplaintListResDto;
+import kdt.minone.domain.complaint.entity.Complaint;
+import kdt.minone.domain.complaint.entity.ComplaintResult;
 import kdt.minone.domain.complaint.repository.ComplaintRepository;
+import kdt.minone.domain.complaint.repository.ComplaintResultRepository;
 import kdt.minone.domain.user.repository.CitizenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -17,6 +23,7 @@ public class UserComplaintService {
 
     private final ComplaintRepository complaintRepository;
     private final CitizenRepository citizenRepository;
+    private final ComplaintResultRepository complaintResultRepository;
 
     @Transactional(readOnly = true)
     public List<CitizenComplaintListResDto> searchComplaintsByUser(Long userId, int page, int size, String complaintNo, String content, String status) {
@@ -24,5 +31,16 @@ public class UserComplaintService {
         Pageable pageable = PageRequest.of(page - 1, size);
 
         return complaintRepository.searchComplaintsByUser(pageable, userId, complaintNo, content, status).stream().toList();
+    }
+
+    @Transactional(readOnly = true)
+    public CitizenComplaintDetailResDto findComplaintById(Long userId, Long complaintId) {
+        Complaint complaint = complaintRepository.findByIdAndCitizenId(complaintId, userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "not found"));
+
+        ComplaintResult result = complaintResultRepository.findByComplaintId(complaintId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "not found"));
+
+        return new CitizenComplaintDetailResDto(complaint, result);
     }
 }

--- a/src/main/java/kdt/minone/global/enums/ComplaintStatus.java
+++ b/src/main/java/kdt/minone/global/enums/ComplaintStatus.java
@@ -1,5 +1,8 @@
 package kdt.minone.global.enums;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
 public enum ComplaintStatus {
 
     ASSIGNED("접수"),
@@ -7,6 +10,16 @@ public enum ComplaintStatus {
     OFFICIAL_ASSIGNED("담당자 배정"),
     COMPLETED("완료"),
     CANCELLED("접수 취소");
+
+    public static ComplaintStatus of(String name) {
+        for (ComplaintStatus status : values()) {
+            if (status.name().equals(name)) {
+                return status;
+            }
+        }
+
+        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "not found");
+    }
 
     private final String description;
 


### PR DESCRIPTION
### 구현 사항
- 시민 민원 전체 조회 기능 구현
   - 접수번호, 내용, 처리상태 기반 조회이며 필수 조건 아님
   - 조건 없을 경우, 전체 조회
   - QueryDsl 적용

#31

- 시민 민원 단건 조회 기능 구현

#32

### 수정 사항
- Compliant Entity 생성자 파라미터 수정
   - complaintNo(접수번호, UUID)는 자동 생성되므로 생성자 파라미터에서 제외