### PR TITLE
채팅방 수정 및 삭제

### DIFF
--- a/src/main/java/kdt/minone/domain/chat/controller/UserChatRoomController.java
+++ b/src/main/java/kdt/minone/domain/chat/controller/UserChatRoomController.java
@@ -34,4 +34,15 @@ public class UserChatRoomController {
                 result
         ), HttpStatus.OK);
     }
+
+    @DeleteMapping("/{chatRoomId}")
+    public ResponseEntity<Void> deleteChatRoomById(
+            @PathVariable Long userId,
+            @PathVariable Long chatRoomId
+    ) {
+
+        userChatRoomService.deleteChatRoomById(userId, chatRoomId);
+
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
 }

--- a/src/main/java/kdt/minone/domain/chat/controller/UserChatRoomController.java
+++ b/src/main/java/kdt/minone/domain/chat/controller/UserChatRoomController.java
@@ -1,0 +1,37 @@
+package kdt.minone.domain.chat.controller;
+
+import kdt.minone.domain.chat.dto.ChatRoomResDto;
+import kdt.minone.domain.chat.dto.ChatRoomUpdateReqDto;
+import kdt.minone.domain.chat.service.UserChatRoomService;
+import kdt.minone.global.common.dto.BaseResDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users/{userId}/chat-rooms")
+public class UserChatRoomController {
+
+    private final UserChatRoomService userChatRoomService;
+
+    @PatchMapping("/{chatRoomId}")
+    public ResponseEntity<BaseResDto<ChatRoomResDto>> updateChatRoomById(
+            @PathVariable Long userId,
+            @PathVariable Long chatRoomId,
+            @RequestBody ChatRoomUpdateReqDto dto
+    ) {
+
+        ChatRoomResDto result = userChatRoomService.updateChatRoomById(
+                userId,
+                chatRoomId,
+                dto.getTitle()
+        );
+
+        return new ResponseEntity<>(new BaseResDto<>(
+                "채팅방 수정 성공",
+                result
+        ), HttpStatus.OK);
+    }
+}

--- a/src/main/java/kdt/minone/domain/chat/dto/ChatRoomResDto.java
+++ b/src/main/java/kdt/minone/domain/chat/dto/ChatRoomResDto.java
@@ -1,0 +1,27 @@
+package kdt.minone.domain.chat.dto;
+
+import kdt.minone.domain.chat.entity.ChatRoom;
+import kdt.minone.global.common.dto.BaseDtoDataType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class ChatRoomResDto implements BaseDtoDataType {
+
+    private final Long id;
+    private final Long citizenId;
+    private final String title;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public ChatRoomResDto(ChatRoom chatRoom) {
+        this.id = chatRoom.getId();
+        this.citizenId = chatRoom.getCitizen().getId();
+        this.title = chatRoom.getTitle();
+        this.createdAt = chatRoom.getCreatedAt();
+        this.updatedAt = chatRoom.getUpdatedAt();
+    }
+}

--- a/src/main/java/kdt/minone/domain/chat/dto/ChatRoomUpdateReqDto.java
+++ b/src/main/java/kdt/minone/domain/chat/dto/ChatRoomUpdateReqDto.java
@@ -1,0 +1,11 @@
+package kdt.minone.domain.chat.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ChatRoomUpdateReqDto {
+
+    private final String title;
+}

--- a/src/main/java/kdt/minone/domain/chat/entity/ChatHistory.java
+++ b/src/main/java/kdt/minone/domain/chat/entity/ChatHistory.java
@@ -27,13 +27,14 @@ public class ChatHistory extends BaseEntity {
     @Column(nullable = false, columnDefinition = "text")
     private String content;
 
-    private boolean isAi = true;
+    private boolean isAi;
 
     @OneToMany(mappedBy = "chatHistory", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ComplaintFile> complaintFiles = new ArrayList<>();
 
-    public ChatHistory(ChatRoom chatRoom, String content) {
+    public ChatHistory(ChatRoom chatRoom, String content, boolean isAi) {
         this.chatRoom = chatRoom;
         this.content = content;
+        this.isAi = isAi;
     }
 }

--- a/src/main/java/kdt/minone/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/kdt/minone/domain/chat/entity/ChatRoom.java
@@ -29,6 +29,9 @@ public class ChatRoom extends BaseEntity {
     @JoinColumn(name = "citizen_id", nullable = false)
     private Citizen citizen;
 
+    @Column(length = 100, nullable = false)
+    private String title;
+
     private boolean isDeleted;
 
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -37,7 +40,8 @@ public class ChatRoom extends BaseEntity {
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Complaint> complaints = new ArrayList<>();
 
-    public ChatRoom(Citizen citizen) {
+    public ChatRoom(Citizen citizen, String title) {
         this.citizen = citizen;
+        this.title = title;
     }
 }

--- a/src/main/java/kdt/minone/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/kdt/minone/domain/chat/entity/ChatRoom.java
@@ -44,4 +44,8 @@ public class ChatRoom extends BaseEntity {
         this.citizen = citizen;
         this.title = title;
     }
+
+    public void updateChatRoom(String title) {
+        this.title = title;
+    }
 }

--- a/src/main/java/kdt/minone/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/kdt/minone/domain/chat/repository/ChatRoomRepository.java
@@ -2,6 +2,16 @@ package kdt.minone.domain.chat.repository;
 
 import kdt.minone.domain.chat.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    default ChatRoom findByIdOrElseThrow(Long chatRoomId) {
+        return findById(chatRoomId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "not found"));
+    }
+
+    Optional<ChatRoom> findByIdAndCitizenId(Long chatRoomId, Long citizenId);
 }

--- a/src/main/java/kdt/minone/domain/chat/service/UserChatRoomService.java
+++ b/src/main/java/kdt/minone/domain/chat/service/UserChatRoomService.java
@@ -24,4 +24,12 @@ public class UserChatRoomService {
 
         return new ChatRoomResDto(chatRoom);
     }
+
+    @Transactional
+    public void deleteChatRoomById(Long userId, Long chatRoomId) {
+        ChatRoom chatRoom = chatRoomRepository.findByIdAndCitizenId(chatRoomId, userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "not found"));
+
+        chatRoomRepository.delete(chatRoom);
+    }
 }

--- a/src/main/java/kdt/minone/domain/chat/service/UserChatRoomService.java
+++ b/src/main/java/kdt/minone/domain/chat/service/UserChatRoomService.java
@@ -1,0 +1,27 @@
+package kdt.minone.domain.chat.service;
+
+import kdt.minone.domain.chat.dto.ChatRoomResDto;
+import kdt.minone.domain.chat.entity.ChatRoom;
+import kdt.minone.domain.chat.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class UserChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    @Transactional
+    public ChatRoomResDto updateChatRoomById(Long userId, Long chatRoomId, String title) {
+        ChatRoom chatRoom = chatRoomRepository.findByIdAndCitizenId(chatRoomId, userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "not found"));
+
+        chatRoom.updateChatRoom(title);
+
+        return new ChatRoomResDto(chatRoom);
+    }
+}


### PR DESCRIPTION
### 구현 사항
- 채팅방 제목 수정 기능 구현
- 채팅방 삭제 기능 구현

#58, #59

### 수정 사항
- ChatRoom Entity에 title 필드 추가
- ChatHistory Entity 생성자 파라미터 수정
  - AI 메시지와 사용자 메시지가 같이 저장되기 때문에 생성자에 isAi 파라미터 추가
  - isAi 필드 기본값을 true → false로 변경