### PR TITLE
채팅방 조회

### DIFF
--- a/src/main/java/kdt/minone/domain/chat/controller/UserChatRoomController.java
+++ b/src/main/java/kdt/minone/domain/chat/controller/UserChatRoomController.java
@@ -1,5 +1,6 @@
 package kdt.minone.domain.chat.controller;
 
+import kdt.minone.domain.chat.dto.ChatRoomDetailResDto;
 import kdt.minone.domain.chat.dto.ChatRoomResDto;
 import kdt.minone.domain.chat.dto.ChatRoomUpdateReqDto;
 import kdt.minone.domain.chat.service.UserChatRoomService;
@@ -29,6 +30,21 @@ public class UserChatRoomController {
         return new ResponseEntity<>(new BaseListResDto<>(
                 "채팅방 전체 조회 성공",
                 results
+        ), HttpStatus.OK);
+    }
+
+    @GetMapping("/{chatRoomId}")
+    public ResponseEntity<BaseResDto<ChatRoomDetailResDto>> findChatRoomById(
+            @PathVariable Long userId,
+            @PathVariable Long chatRoomId,
+            @RequestParam(required = false) Integer limit
+    ) {
+
+        ChatRoomDetailResDto result = userChatRoomService.findChatRoomById(userId, chatRoomId, limit);
+
+        return new ResponseEntity<>(new BaseResDto<>(
+                "채팅방 단건 조회 성공",
+                result
         ), HttpStatus.OK);
     }
 

--- a/src/main/java/kdt/minone/domain/chat/controller/UserChatRoomController.java
+++ b/src/main/java/kdt/minone/domain/chat/controller/UserChatRoomController.java
@@ -3,11 +3,14 @@ package kdt.minone.domain.chat.controller;
 import kdt.minone.domain.chat.dto.ChatRoomResDto;
 import kdt.minone.domain.chat.dto.ChatRoomUpdateReqDto;
 import kdt.minone.domain.chat.service.UserChatRoomService;
+import kdt.minone.global.common.dto.BaseListResDto;
 import kdt.minone.global.common.dto.BaseResDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,6 +18,19 @@ import org.springframework.web.bind.annotation.*;
 public class UserChatRoomController {
 
     private final UserChatRoomService userChatRoomService;
+
+    @GetMapping
+    public ResponseEntity<BaseListResDto<ChatRoomResDto>> findAll(
+            @PathVariable Long userId
+    ) {
+
+        List<ChatRoomResDto> results = userChatRoomService.findAll(userId);
+
+        return new ResponseEntity<>(new BaseListResDto<>(
+                "채팅방 전체 조회 성공",
+                results
+        ), HttpStatus.OK);
+    }
 
     @PatchMapping("/{chatRoomId}")
     public ResponseEntity<BaseResDto<ChatRoomResDto>> updateChatRoomById(

--- a/src/main/java/kdt/minone/domain/chat/dto/ChatRoomDetailResDto.java
+++ b/src/main/java/kdt/minone/domain/chat/dto/ChatRoomDetailResDto.java
@@ -1,0 +1,23 @@
+package kdt.minone.domain.chat.dto;
+
+import kdt.minone.domain.chat.entity.ChatRoom;
+import kdt.minone.global.common.dto.BaseDtoDataType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class ChatRoomDetailResDto implements BaseDtoDataType {
+
+    private final Long chatRoomId;
+    private final String chatRoomTitle;
+    private final List<MessageResDto> messages;
+
+    public ChatRoomDetailResDto(ChatRoom chatRoom, List<MessageResDto> messages) {
+        this.chatRoomId = chatRoom.getId();
+        this.chatRoomTitle = chatRoom.getTitle();
+        this.messages = messages;
+    }
+}

--- a/src/main/java/kdt/minone/domain/chat/dto/MessageResDto.java
+++ b/src/main/java/kdt/minone/domain/chat/dto/MessageResDto.java
@@ -1,0 +1,23 @@
+package kdt.minone.domain.chat.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class MessageResDto {
+
+    private final Long messageId;
+    private final boolean isAi;
+    private final String content;
+    private final LocalDateTime createdAt;
+
+    @QueryProjection
+    public MessageResDto(Long messageId, boolean isAi, String content, LocalDateTime createdAt) {
+        this.messageId = messageId;
+        this.isAi = isAi;
+        this.content = content;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/kdt/minone/domain/chat/repository/ChatHistoryRepository.java
+++ b/src/main/java/kdt/minone/domain/chat/repository/ChatHistoryRepository.java
@@ -3,5 +3,5 @@ package kdt.minone.domain.chat.repository;
 import kdt.minone.domain.chat.entity.ChatHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ChatHistoryRepository extends JpaRepository<ChatHistory, Long> {
+public interface ChatHistoryRepository extends JpaRepository<ChatHistory, Long>, CustomChatHistoryRepository {
 }

--- a/src/main/java/kdt/minone/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/kdt/minone/domain/chat/repository/ChatRoomRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
@@ -14,4 +15,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     }
 
     Optional<ChatRoom> findByIdAndCitizenId(Long chatRoomId, Long citizenId);
+
+    List<ChatRoom> findAllByCitizenId(Long userId);
 }

--- a/src/main/java/kdt/minone/domain/chat/repository/CustomChatHistoryRepository.java
+++ b/src/main/java/kdt/minone/domain/chat/repository/CustomChatHistoryRepository.java
@@ -1,0 +1,10 @@
+package kdt.minone.domain.chat.repository;
+
+import kdt.minone.domain.chat.dto.MessageResDto;
+
+import java.util.List;
+
+public interface CustomChatHistoryRepository {
+
+    List<MessageResDto> findAllWithLimit(Long chatRoomId, Integer limit);
+}

--- a/src/main/java/kdt/minone/domain/chat/repository/CustomChatHistoryRepositoryImpl.java
+++ b/src/main/java/kdt/minone/domain/chat/repository/CustomChatHistoryRepositoryImpl.java
@@ -7,6 +7,7 @@ import kdt.minone.domain.chat.dto.QMessageResDto;
 import kdt.minone.domain.chat.entity.QChatHistory;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Collections;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -33,6 +34,9 @@ public class CustomChatHistoryRepositoryImpl implements CustomChatHistoryReposit
             messageQuery.limit(limit);
         }
 
-        return messageQuery.fetch();
+        List<MessageResDto> messages = messageQuery.fetch();
+        Collections.reverse(messages);
+        
+        return messages;
     }
 }

--- a/src/main/java/kdt/minone/domain/chat/repository/CustomChatHistoryRepositoryImpl.java
+++ b/src/main/java/kdt/minone/domain/chat/repository/CustomChatHistoryRepositoryImpl.java
@@ -1,0 +1,38 @@
+package kdt.minone.domain.chat.repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kdt.minone.domain.chat.dto.MessageResDto;
+import kdt.minone.domain.chat.dto.QMessageResDto;
+import kdt.minone.domain.chat.entity.QChatHistory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomChatHistoryRepositoryImpl implements CustomChatHistoryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<MessageResDto> findAllWithLimit(Long chatRoomId, Integer limit) {
+        QChatHistory chatHistory = QChatHistory.chatHistory;
+
+        JPAQuery<MessageResDto> messageQuery = jpaQueryFactory
+                .select(new QMessageResDto(
+                        chatHistory.id,
+                        chatHistory.isAi,
+                        chatHistory.content,
+                        chatHistory.createdAt
+                ))
+                .from(chatHistory)
+                .where(chatHistory.chatRoom.id.eq(chatRoomId))
+                .orderBy(chatHistory.createdAt.desc());
+
+        if (limit != null) {
+            messageQuery.limit(limit);
+        }
+
+        return messageQuery.fetch();
+    }
+}

--- a/src/main/java/kdt/minone/domain/chat/service/UserChatRoomService.java
+++ b/src/main/java/kdt/minone/domain/chat/service/UserChatRoomService.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class UserChatRoomService {
@@ -31,5 +33,14 @@ public class UserChatRoomService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "not found"));
 
         chatRoomRepository.delete(chatRoom);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRoomResDto> findAll(Long userId) {
+        List<ChatRoom> chatRooms = chatRoomRepository.findAllByCitizenId(userId);
+
+        return chatRooms.stream()
+                .map(ChatRoomResDto::new)
+                .toList();
     }
 }

--- a/src/main/java/kdt/minone/domain/chat/service/UserChatRoomService.java
+++ b/src/main/java/kdt/minone/domain/chat/service/UserChatRoomService.java
@@ -1,7 +1,10 @@
 package kdt.minone.domain.chat.service;
 
+import kdt.minone.domain.chat.dto.ChatRoomDetailResDto;
 import kdt.minone.domain.chat.dto.ChatRoomResDto;
+import kdt.minone.domain.chat.dto.MessageResDto;
 import kdt.minone.domain.chat.entity.ChatRoom;
+import kdt.minone.domain.chat.repository.ChatHistoryRepository;
 import kdt.minone.domain.chat.repository.ChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,6 +19,7 @@ import java.util.List;
 public class UserChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatHistoryRepository chatHistoryRepository;
 
     @Transactional
     public ChatRoomResDto updateChatRoomById(Long userId, Long chatRoomId, String title) {
@@ -42,5 +46,15 @@ public class UserChatRoomService {
         return chatRooms.stream()
                 .map(ChatRoomResDto::new)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ChatRoomDetailResDto findChatRoomById(Long userId, Long chatRoomId, Integer limit) {
+        ChatRoom chatRoom = chatRoomRepository.findByIdAndCitizenId(chatRoomId, userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "not found"));
+
+        List<MessageResDto> messages = chatHistoryRepository.findAllWithLimit(chatRoomId, limit);
+
+        return new ChatRoomDetailResDto(chatRoom, messages);
     }
 }


### PR DESCRIPTION
### 구현 사항
- 채팅방 전체 조회 기능 구현

#60

- 채팅방 단건 조회 기능 구현
   - limit 파라미터를 보내면 채팅 메시지를 최신순 상태에서 개수 제한
   - limit 없이 조회할 경우, 해당 채팅방의 전체 메시지 조회
   - 오름차순 정렬

#61